### PR TITLE
Feature/accessible gifffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Include `gifffer.min.js` in your page.
 <script type="text/javascript" src="gifffer.min.js"></script>
 ```
 
-Instead of setting `src` attribute on your image use `data-gifffer`.  
+Instead of setting `src` attribute on your image use `data-gifffer`.
 
 ```html
 <img data-gifffer="image.gif" />

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Include `gifffer.min.js` in your page.
 <script type="text/javascript" src="gifffer.min.js"></script>
 ```
 
-Instead of setting `src` attribute on your image use `data-gifffer`.
+Instead of setting `src` attribute on your image use `data-gifffer`.  
 
 ```html
 <img data-gifffer="image.gif" />
@@ -28,6 +28,12 @@ At the end, call `Gifffer();` so you replace the normal gifs with playable gifs.
 window.onload = function() {
   Gifffer();
 }
+```
+
+For accessibility, instead of setting `alt` attribute on your image, you may use `data-gifffer-alt` (optional).
+
+```html
+<img data-gifffer="image.gif" data-gifffer-alt="some alt description"/>
 ```
 
 The Gifffer function returns an array of nodes that could be used to simulate clicks. For Example:

--- a/index.html
+++ b/index.html
@@ -42,6 +42,11 @@
         </section>
         <hr />
         <section>
+            <p>With Alt Text (for screen readers)<br /><small>&lt;img data-gifffer="image.gif"<br>data-gifffer-alt="some alt description of gif" /></small></p>
+            <img data-gifffer="./imgs/image.gif" data-gifffer-alt="some alt description of gif" />
+        </section>
+        <hr />
+        <section>
             <p>Setting string size in pixels<br /><small>&lt;img data-gifffer="image-big.gif"<br />data-gifffer-width="250" data-gifffer-height="100" /></small></p>
             <img data-gifffer="./imgs/image-big.gif" data-gifffer-width="250" data-gifffer-height="100" class="image-big"/>
         </section>

--- a/lib/gifffer.js
+++ b/lib/gifffer.js
@@ -74,7 +74,7 @@ function calculatePercentageDim (el, w, h, wOrig, hOrig) {
 };
 
 function process(el, gifs) {
-  var url, con, c, w, h, duration,play, gif, playing = false, cc, isC, durationTimeout, dims, trngl, altText;
+  var url, con, c, w, h, duration,play, gif, playing = false, cc, isC, durationTimeout, dims, altText;
 
   url = el.getAttribute('data-gifffer');
   w = el.getAttribute('data-gifffer-width');

--- a/lib/gifffer.js
+++ b/lib/gifffer.js
@@ -24,7 +24,8 @@ function formatUnit(v) {
   return v + (v.toString().indexOf('%') > 0 ? '' : 'px');
 };
 
-function createContainer(w, h, el) {
+function createContainer(w, h, el, altText) {
+  var alt;
   var con = d.createElement('BUTTON');
   var cls = el.getAttribute('class');
   var id = el.getAttribute('id');
@@ -32,6 +33,7 @@ function createContainer(w, h, el) {
   cls ? con.setAttribute('class', el.getAttribute('class')) : null;
   id ? con.setAttribute('id', el.getAttribute('id')) : null;
   con.setAttribute('style', 'position:relative;cursor:pointer;background:none;border:none;padding:0;');
+  con.setAttribute('aria-hidden', 'true');
 
   // creating play button
   var play = d.createElement('DIV');
@@ -39,12 +41,21 @@ function createContainer(w, h, el) {
   play.setAttribute('style', 'width:' + playSize + 'px;height:' + playSize + 'px;border-radius:' + (playSize/2) + 'px;background:rgba(0, 0, 0, 0.3);position:absolute;');
 
   var trngl = d.createElement('DIV');
-  trngl.setAttribute('style', 'width:0;height: 0;border-top:14px solid transparent;border-bottom:14px solid transparent;border-left:14px solid rgba(0, 0, 0, 0.5);position:absolute;left:26px;top:16px;')
+  trngl.setAttribute('style', 'width:0;height: 0;border-top:14px solid transparent;border-bottom:14px solid transparent;border-left:14px solid rgba(0, 0, 0, 0.5);position:absolute;left:26px;top:16px;');
   play.appendChild(trngl);
+
+  // create alt text if available
+  if (altText) {
+    alt = d.createElement('p');
+    alt.setAttribute('class','gifffer-alt');
+    alt.setAttribute('style', 'border:0;clip:rect(0 0 0 0);height:1px;overflow:hidden;padding:0;position:absolute;width:1px;');
+    alt.innerText = altText + ', image';
+  }
 
   // dom placement
   con.appendChild(play);
   el.parentNode.replaceChild(con, el);
+  altText ? con.parentNode.insertBefore(alt, con.nextSibling) : null;
   return { c: con, p: play };
 };
 
@@ -63,18 +74,19 @@ function calculatePercentageDim (el, w, h, wOrig, hOrig) {
 };
 
 function process(el, gifs) {
-  var url, con, c, w, h, duration,play, gif, playing = false, cc, isC, durationTimeout, dims;
+  var url, con, c, w, h, duration,play, gif, playing = false, cc, isC, durationTimeout, dims, trngl, altText;
 
   url = el.getAttribute('data-gifffer');
   w = el.getAttribute('data-gifffer-width');
   h = el.getAttribute('data-gifffer-height');
   duration = el.getAttribute('data-gifffer-duration');
+  altText = el.getAttribute('data-gifffer-alt');
   el.style.display = 'block';
 
   // creating the canvas
   c = document.createElement('canvas');
   isC = !!(c.getContext && c.getContext('2d'));
-  if(w && h && isC) cc = createContainer(w, h, el);
+  if(w && h && isC) cc = createContainer(w, h, el, altText);
 
   // waiting for image load
   el.onload = function() {
@@ -84,12 +96,12 @@ function process(el, gifs) {
     h = h || el.height;
 
     // creating the container
-    if (!cc) cc = createContainer(w, h, el);
+    if (!cc) cc = createContainer(w, h, el, altText);
     con = cc.c;
     play = cc.p;
     dims = calculatePercentageDim(con, w, h, el.width, el.height);
 
-    //add the container to the gif arraylist
+    // add the container to the gif arraylist
     gifs.push(con);
 
     // listening for image click


### PR DESCRIPTION
#15 

- if `data-gifffer-alt` provided, appends a p tag with the [visually hidden](http://thibaultjanbeyer.github.io/learn-accesibility/visual.html#Hiding-Elements-3) alt description to provide an [alternative image](http://thibaultjanbeyer.github.io/learn-accesibility/visual.html#Images) description for screen reader users.

<img width="999" alt="gifffer-alt" src="https://cloud.githubusercontent.com/assets/12467511/16557218/c867c5ca-41de-11e6-8f8a-67d769ceca90.png">

- hide the container from screen reader users with `aria-hidden` (since it is a button now, that might confuse them since the screen reader would read ', button' without any context making it difficult to understand what it does)