### PR TITLE
set responsive sizes after draw

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,7 +58,7 @@
         <hr />
         <section style="border:solid 1px #999;">
             <p>Filling up the whole space<br /><small>&lt;img data-gifffer="image-big.gif" data-gifffer-width="100%" /></small></p>
-            <img data-gifffer="./imgs/image-big.gif" data-gifffer-width="100%%" class="image-big"/>
+            <img data-gifffer="./imgs/image-big.gif" data-gifffer-width="100%" class="image-big"/>
         </section>
         <hr />
         <section>

--- a/lib/gifffer.js
+++ b/lib/gifffer.js
@@ -38,7 +38,7 @@ function createContainer(w, h, el, altText) {
   // creating play button
   var play = d.createElement('DIV');
   play.setAttribute('class','gifffer-play-button');
-  play.setAttribute('style', 'width:' + playSize + 'px;height:' + playSize + 'px;border-radius:' + (playSize/2) + 'px;background:rgba(0, 0, 0, 0.3);position:absolute;');
+  play.setAttribute('style', 'width:' + playSize + 'px;height:' + playSize + 'px;border-radius:' + (playSize/2) + 'px;background:rgba(0, 0, 0, 0.3);position:absolute;top:50%;left:50%;margin:-' + (playSize/2) + 'px');
 
   var trngl = d.createElement('DIV');
   trngl.setAttribute('style', 'width:0;height: 0;border-top:14px solid transparent;border-bottom:14px solid transparent;border-left:14px solid rgba(0, 0, 0, 0.5);position:absolute;left:26px;top:16px;');
@@ -68,6 +68,10 @@ function calculatePercentageDim (el, w, h, wOrig, hOrig) {
     w = parseInt(w.toString().replace('%', ''));
     w = (w / 100) * parentDimW;
     h = w / ratio;
+  } else if (h.toString().indexOf('%') > 0) {
+    h = parseInt(h.toString().replace('%', ''));
+    h = (h / 100) * parentDimW;
+    w = h / ratio;
   }
 
   return { w: w, h: h };
@@ -110,7 +114,7 @@ function process(el, gifs) {
       if(!playing) {
         playing = true;
         gif = document.createElement('IMG');
-        gif.setAttribute('style', 'width:' + dims.w + 'px;height:' + dims.h + 'px;');
+        gif.setAttribute('style', 'width:100%;height:100%;');
         gif.setAttribute('data-uri', Math.floor(Math.random()*100000) + 1);
         setTimeout(function() {
           gif.src = url;
@@ -142,16 +146,29 @@ function process(el, gifs) {
     c.getContext('2d').drawImage(el, 0, 0, dims.w, dims.h);
     con.appendChild(c);
 
-    // reposition the play button
-    play.style.top = ((dims.h / 2) - (playSize / 2)) + 'px';
-    play.style.left = ((dims.w / 2) - (playSize / 2)) + 'px';
-
     // setting the actual image size
     con.setAttribute('style', 'position:relative;cursor:pointer;width:' + dims.w + 'px;height:' + dims.h + 'px;background:none;border:none;padding:0;');
 
-  }
+    c.style.width = '100%';
+    c.style.height = '100%';
+    
+    if (w.toString().indexOf('%') > 0 && h.toString().indexOf('%') > 0) {
+      con.style.width = w;
+      con.style.height = h;
+    } else if (w.toString().indexOf('%') > 0) {
+      con.style.width = w;
+      con.style.height = 'inherit';
+    } else if (h.toString().indexOf('%') > 0) {
+      con.style.width = 'inherit';
+      con.style.height = h;
+    } else {
+      con.style.width = dims.w + 'px';
+      con.style.height = dims.h + 'px';
+    }
+
+  };
   el.src = url;
-};
+}
 
 return Gifffer;
 


### PR DESCRIPTION
Fix to #9 
- After image is drawn to canvas, add % sizes to container for liquid layout.
- Also set the play button, gif image and canvas in relative position to the container.
- Remove typo in index.html

You might try it out. Worked for me:
![responsive](https://cloud.githubusercontent.com/assets/12467511/16648246/601f801e-4433-11e6-9076-4c20aa89c193.gif)

